### PR TITLE
fix/change message subject subscription

### DIFF
--- a/src/overrides/core/server/services/members/api.js
+++ b/src/overrides/core/server/services/members/api.js
@@ -43,7 +43,7 @@ function createApiInstance(config) {
                 const siteTitle = settingsCache.get('title');
                 switch (type) {
                 case 'subscribe':
-                    return `Confirma tu suscripción la Newsletter de Henry 🚀`;
+                    return `Confirma tu suscripción a la Newsletter de Henry 🚀`;
                 case 'signup':
                     return `Complete your sign up to ${siteTitle}! 🚀`;
                 case 'updateEmail':


### PR DESCRIPTION
Se agrega un cambio en el asunto del mail observado por Flor: _Solo agregaría en el asunto "a la Newsletter": Confirma tu suscripción la Newsletter de Henry_ 
Ese archivo api.js de la folder overrides debería reemplazar al actual.-